### PR TITLE
Update SabreTools libraries and add .NET 9 support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/IRDKit/IRDKit.csproj
+++ b/IRDKit/IRDKit.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Assembly Properties -->
     <OutputType>Exe</OutputType>
     <TargetName>irdkit</TargetName>
     <AssemblyName>irdkit</AssemblyName>
-	<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+	<TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <LangVersion>latest</LangVersion>
@@ -30,8 +30,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="SabreTools.Hashing" Version="1.1.4" />
-    <PackageReference Include="SabreTools.RedumpLib" Version="1.3.4" />
+    <PackageReference Include="SabreTools.Hashing" Version="1.4.0" />
+    <PackageReference Include="SabreTools.RedumpLib" Version="1.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IRDKit/Program.cs
+++ b/IRDKit/Program.cs
@@ -944,13 +944,8 @@ namespace IRDKit
             uint crc32UInt = BitConverter.ToUInt32(crc32, 0);
 
             // Search for ISO on redump.org
-#if !NETFRAMEWORK
-            RedumpHttpClient redump = new();
+            RedumpClient redump = new();
             List<int> ids = redump.CheckSingleSitePage("http://redump.org/discs/system/ps3/quicksearch/" + crc32String).ConfigureAwait(false).GetAwaiter().GetResult();
-#else
-            RedumpWebClient redump = new();
-            List<int> ids = redump.CheckSingleSitePage("http://redump.org/discs/system/ps3/quicksearch/" + crc32String);
-#endif
             int id;
             if (ids.Count == 0)
             {
@@ -963,11 +958,7 @@ namespace IRDKit
                 string sha1String = HashTool.GetFileHash(isoPath, HashType.SHA1);
 
                 // Search redump.org for SHA1 hash
-#if !NETFRAMEWORK
                 List<int> ids2 = redump.CheckSingleSitePage("http://redump.org/discs/system/ps3/quicksearch/" + sha1String).ConfigureAwait(false).GetAwaiter().GetResult();
-#else
-                List<int> ids2 = redump.CheckSingleSitePage("http://redump.org/discs/system/ps3/quicksearch/" + sha1String);
-#endif
                 if (ids2.Count == 0)
                 {
                     Console.Error.WriteLine("ISO not found in redump and no valid key provided, cannot create IRD");
@@ -987,12 +978,8 @@ namespace IRDKit
             }
 
             // Download key file from redump.org
-#if !NETFRAMEWORK
-            byte[] key = redump.GetByteArrayAsync($"http://redump.org/disc/{id}/key").ConfigureAwait(false).GetAwaiter().GetResult();
-#else
-            byte[] key = redump.DownloadData($"http://redump.org/disc/{id}/key");
-#endif
-            if (key.Length != 16)
+            byte[]? key = redump.DownloadData($"http://redump.org/disc/{id}/key").ConfigureAwait(false).GetAwaiter().GetResult();
+            if (key == null || key.Length != 16)
             {
                 Console.Error.WriteLine("Invalid key obtained from redump and no valid key provided, cannot create IRD");
                 return null;

--- a/IRDKit/Program.cs
+++ b/IRDKit/Program.cs
@@ -978,7 +978,7 @@ namespace IRDKit
             }
 
             // Download key file from redump.org
-            byte[]? key = redump.DownloadData($"http://redump.org/disc/{id}/key").ConfigureAwait(false).GetAwaiter().GetResult();
+            byte[] key = redump.DownloadData($"http://redump.org/disc/{id}/key").ConfigureAwait(false).GetAwaiter().GetResult();
             if (key == null || key.Length != 16)
             {
                 Console.Error.WriteLine("Invalid key obtained from redump and no valid key provided, cannot create IRD");

--- a/LibIRD/LibIRD.csproj
+++ b/LibIRD/LibIRD.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Assembly Properties -->
@@ -23,11 +23,11 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith(`osx-arm`))">
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup Condition="!$(RuntimeIdentifier.StartsWith(`osx-arm`))">
-    <TargetFrameworks>net20;net35;net40;net452;net462;net472;net48;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net452;net462;net472;net48;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SabreTools.Hashing" Version="1.1.4" />
+    <PackageReference Include="SabreTools.Hashing" Version="1.4.0" />
   </ItemGroup>
 
 </Project>

--- a/LibIRD/LibIRD.csproj
+++ b/LibIRD/LibIRD.csproj
@@ -9,7 +9,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Version>0.9.1</Version>
     <PackageOutputPath>../nupkg</PackageOutputPath>
-    
+
+    <!-- Avoid inexact read with 'System.IO.Stream.Read' -->
+    <NoWarn>CA2022</NoWarn>
+
     <!-- Package Properties -->
     <Authors>Deterous</Authors>
     <Description>Library for ISO Rebuild Data</Description>
@@ -32,6 +35,11 @@
 
   <ItemGroup>
     <None Include="./README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <!-- Support for old .NET versions -->
+  <ItemGroup Condition="$(TargetFramework.StartsWith(`net2`))">
+      <PackageReference Include="Net30.LinqBridge" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/publish-irdkit.ps1
+++ b/publish-irdkit.ps1
@@ -1,15 +1,15 @@
-dotnet publish -c Release -f net8.0 -r win-x86 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
-dotnet publish -c Release -f net8.0 -r win-x64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
-dotnet publish -c Release -f net8.0 -r win-arm64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
-dotnet publish -c Release -f net8.0 -r linux-x64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
-dotnet publish -c Release -f net8.0 -r linux-arm64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
-dotnet publish -c Release -f net8.0 -r osx-x64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
-dotnet publish -c Release -f net8.0 -r osx-arm64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
+dotnet publish -c Release -f net9.0 -r win-x86 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
+dotnet publish -c Release -f net9.0 -r win-x64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
+dotnet publish -c Release -f net9.0 -r win-arm64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
+dotnet publish -c Release -f net9.0 -r linux-x64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
+dotnet publish -c Release -f net9.0 -r linux-arm64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
+dotnet publish -c Release -f net9.0 -r osx-x64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
+dotnet publish -c Release -f net9.0 -r osx-arm64 --self-contained=false  -p:PublishSingleFile=true -p:DebugType=None IRDKit\IRDKit.csproj
 
-Compress-Archive -Path "./IRDKit/bin/Release/net8.0/win-x86/publish/irdkit.exe" -Destination "./irdkit-win-x86.zip" -CompressionLevel "Optimal"
-Compress-Archive -Path "./IRDKit/bin/Release/net8.0/win-x64/publish/irdkit.exe" -Destination "./irdkit-win-x64.zip" -CompressionLevel "Optimal"
-Compress-Archive -Path "./IRDKit/bin/Release/net8.0/win-arm64/publish/irdkit.exe" -Destination "./irdkit-win-arm64.zip" -CompressionLevel "Optimal"
-Compress-Archive -Path "./IRDKit/bin/Release/net8.0/linux-x64/publish/irdkit" -Destination "./irdkit-linux-x64.zip" -CompressionLevel "Optimal"
-Compress-Archive -Path "./IRDKit/bin/Release/net8.0/linux-arm64/publish/irdkit" -Destination "./irdkit-linux-arm64.zip" -CompressionLevel "Optimal"
-Compress-Archive -Path "./IRDKit/bin/Release/net8.0/osx-x64/publish/irdkit" -Destination "./irdkit-osx-x64.zip" -CompressionLevel "Optimal"
-Compress-Archive -Path "./IRDKit/bin/Release/net8.0/osx-arm64/publish/irdkit" -Destination "./irdkit-osx-arm64.zip" -CompressionLevel "Optimal"
+Compress-Archive -Path "./IRDKit/bin/Release/net9.0/win-x86/publish/irdkit.exe" -Destination "./irdkit-win-x86.zip" -CompressionLevel "Optimal"
+Compress-Archive -Path "./IRDKit/bin/Release/net9.0/win-x64/publish/irdkit.exe" -Destination "./irdkit-win-x64.zip" -CompressionLevel "Optimal"
+Compress-Archive -Path "./IRDKit/bin/Release/net9.0/win-arm64/publish/irdkit.exe" -Destination "./irdkit-win-arm64.zip" -CompressionLevel "Optimal"
+Compress-Archive -Path "./IRDKit/bin/Release/net9.0/linux-x64/publish/irdkit" -Destination "./irdkit-linux-x64.zip" -CompressionLevel "Optimal"
+Compress-Archive -Path "./IRDKit/bin/Release/net9.0/linux-arm64/publish/irdkit" -Destination "./irdkit-linux-arm64.zip" -CompressionLevel "Optimal"
+Compress-Archive -Path "./IRDKit/bin/Release/net9.0/osx-x64/publish/irdkit" -Destination "./irdkit-osx-x64.zip" -CompressionLevel "Optimal"
+Compress-Archive -Path "./IRDKit/bin/Release/net9.0/osx-arm64/publish/irdkit" -Destination "./irdkit-osx-arm64.zip" -CompressionLevel "Optimal"


### PR DESCRIPTION
To allow LibIRD to be used in newer versions of MPF, the following changes are needed:

- Updates SabreTools.Hashing to 1.4.0
- Updates SabreTools.RedumpLib to 1.5.2
- Adds build support for .NET 9

This PR does not update the version number of either LibIRD or IRDKit.